### PR TITLE
Updating devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,35 +1,30 @@
 apiVersion: "1.0.0"
-attributes: 
-  persistVolumes: "false"
-commands: 
-  - 
-    actions: 
-      - 
-        command: "hugo server --disableFastRender --bind 0.0.0.0 --liveReloadPort 443"
-        component: hugo-cli
-        type: exec
-        workdir: "${CHE_PROJECTS_ROOT}/cip-core-portal"
-    name: "run hugo server"
-components: 
-  - 
-    alias: hugo-cli
+metadata: 
+  generateName: cip-portal-
+
+components:
+
+  - alias: hugo-cli
     endpoints: 
-      - 
-        name: 1313/tcp
+      - name: 1313/tcp
         port: 1313
+        attributes:
+          path: /en
     image: "serram/che-hugo-golang:0.64"
     memoryLimit: 512Mi
     mountSources: true
     type: dockerimage
-  - 
-    id: budparr/language-hugo-vscode/latest
+
+  - id: budparr/language-hugo-vscode/latest
     memoryLimit: 512Mi
     type: chePlugin
-metadata: 
-  name: cip-portal
-projects: 
-  - 
-    name: cip-core-portal
-    source: 
-      location: "https://github.com/cip-core-mirrors/cip-core-portal"
-      type: git
+
+
+commands: 
+
+  - name: "run hugo server"
+    actions: 
+      - command: "hugo server --disableFastRender --bind 0.0.0.0 --liveReloadPort 443"
+        component: hugo-cli
+        type: exec
+        workdir: "${CHE_PROJECTS_ROOT}/cip-core-portal"


### PR DESCRIPTION
- use generateName to have unique workspace name
- removing project (would clone the current repo and branch if empty)
- adding a path to the endpoint to avoid redirect to localhost/en issue

Test this PR with `https://<che-or-crw-host>/factory?url=https://github.com/sunix/cip-core-portal/tree/featured-partner-redhat`

PS: I couldn't find `budparr/language-hugo-vscode/latest` plugin location so I removed that one while testing.

Signed-off-by: Sun Tan <sutan@redhat.com>